### PR TITLE
ensure that twinning respects width

### DIFF
--- a/gears20.py
+++ b/gears20.py
@@ -217,16 +217,16 @@ def setLocation(object, context, seen, rot_changed):
         rotation = object.rotation * (1.0 + ratio) - driverrotation * ratio
         if object.name not in seen:
             if object.twin == 'Up':
-                offset += 1
+                offset += context.scene.objects[object.driver].width
             elif object.twin == 'Down':
-                offset -= 1
+                offset -= object.width
 
             object.location = context.scene.objects[object.driver].location
             if object.twin == 'None':  # ! string not None object
                 object.location.x += nx
                 object.location.y += ny
                 print(object.name, degrees(rotation), degrees(driverrotation), context.scene.objects[object.driver].nteeth, object.nteeth)
-            object.location.z += offset * 0.1
+            object.location.z += offset # the offset should be based on the width of the gear and the driver
             #print(object.name, '-->', object.driver, 'driver changed',object.driver in rot_changed, 'odd', object.nteeth % 2 == 1, 'rotated', rot_changed,'seen', seen)
             if ((object.driver in rot_changed) and (object.nteeth % 2 == 1) or (object.driver not in rot_changed) and (object.nteeth % 2 == 0)):
                     rotate_mesh(object, Euler((0, 0, PI / object.nteeth + rotation), 'XYZ'))  # half a tooth + additional rotation


### PR DESCRIPTION
Currently twinning only correctly positions gears in z if the width of the driver is 0.1 yet the default is 0.2. The default of 0.2 means that the twinned gears overlap in the z which means further gears in the chain tend to end up intersecting. The proposed change takes into account the width of the current gear and the driver when calculating the z offset. This correctly positions this gear in respect to the driver regardless of the width of either. What it doesn't solve, however, is that further gears in the train with differing widths may intersect. Ideally a "proper" fix would work all the way backwards to the root gear to ensure that not only is each gear positioned correctly against the driver but so that it also doesn't intersect with any previous gears.
